### PR TITLE
Add internal secret to save state between creation and deletion steps

### DIFF
--- a/Acornfile
+++ b/Acornfile
@@ -58,7 +58,7 @@ jobs: "delete-cluster": {
     MONGODB_ATLAS_PUBLIC_API_KEY: "secret://atlas-creds/public_key"
     MONGODB_ATLAS_PRIVATE_API_KEY: "secret://atlas-creds/private_key"
     MONGODB_ATLAS_PROJECT_ID: "secret://atlas-creds/project_id"
-    CLUSTER_NAME: args.clusterName
+    CLUSTER_NAME: "secret://state/cluster_name"
     DB_USER: "secret://user/username"
   }
   events: ["delete"]
@@ -90,6 +90,13 @@ secrets: {
           private_key: "MONGODB_ATLAS_PRIVATE_API_KEY"
           project_id: "MONGODB_ATLAS_PROJECT_ID"
       }
+  }
+}
+
+secrets: {
+  "state": {
+    type: "generated"
+    params: job: "create-cluster"
   }
 }
 

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -13,27 +13,10 @@ fi
 atlas cluster get ${CLUSTER_NAME} 2>/dev/null
 if [ $? -eq 0 ]; then
   echo "-> cluster ${CLUSTER_NAME} already exists"
-
-  DB_ADDRESS=$(atlas cluster describe ${CLUSTER_NAME} -o json | jq -r .connectionStrings.standardSrv)
-  DB_PROTO=$(echo $DB_ADDRESS | cut -d':' -f1)
-  DB_HOST=$(echo $DB_ADDRESS | cut -d'/' -f3)
-  echo "DB_ADDRESS: [${DB_ADDRESS}] / DB_PROTO:[${DB_PROTO}] / DB_HOST:[${DB_HOST}]"
-
-  cat > /run/secrets/output<<EOF
-  services: atlas: {
-    address: "${DB_HOST}"
-    secrets: ["user"]
-    ports: "27017"
-    data: {
-      proto: "${DB_PROTO}"
-      dbName: "${DB_NAME}"
-    }
-  }
-EOF
-  exit 0
-else
-  echo "-> cluster ${CLUSTER_NAME} does not exist"
+  exit 1
 fi
+
+echo "-> cluster ${CLUSTER_NAME} does not exist"
 
 # Create a cluster in the current project
 echo "-> about to create cluster ${CLUSTER_NAME} of type ${TIER} in ${PROVIDER} / ${REGION}"
@@ -84,6 +67,11 @@ services: atlas: {
   data: {
     proto: "${DB_PROTO}"
     dbName: "${DB_NAME}"
+  }
+}
+secrets: state: {
+  data: {
+    cluster_name: "${CLUSTER_NAME}"
   }
 }
 EOF

--- a/scripts/delete.sh
+++ b/scripts/delete.sh
@@ -10,9 +10,10 @@ if [ "${ACORN_EVENT}" != "delete" ]; then
 fi
 
 # Make sure the cluster exists
+echo "-> checking if cluster ${CLUSTER_NAME} exists"
 atlas cluster get ${CLUSTER_NAME} 2>/dev/null
 if [ $? -ne 0 ]; then
-  echo "cluster ${CLUSTER_NAME} does not exist"
+  echo "-> cluster ${CLUSTER_NAME} does not exist"
   exit 0
 fi
 


### PR DESCRIPTION
This is similar to what has been done for the redis-cloud service. It uses a secret to store the name of the cluster created by the create.sh script. This is useful to make sure the deletion step actually delete the correct cluster (this is a way to avoid the deletion of an existing cluster with the same name)