### PR TITLE
Use acorn external ID to keep track of the cluster

### DIFF
--- a/Acornfile
+++ b/Acornfile
@@ -74,7 +74,7 @@ jobs: "delete-cluster": {
 		MONGODB_ATLAS_PRIVATE_API_KEY: "secret://atlas-creds/private_key"
 		MONGODB_ATLAS_PROJECT_ID:      "secret://atlas-creds/project_id"
 		CLUSTER_NAME:                  args.clusterName
-		DB_USER:                       "secret://user/username"
+		CREATED_USER:                  "secret://state/created_user"
 	}
 	events: ["delete"]
 }
@@ -94,6 +94,13 @@ secrets: {
 			password: ""
 		}
 	}
+}
+
+secrets: {
+  "state": {
+    type: "generated"
+    params: job: "create-cluster"
+  }
 }
 
 if args.useExternalCreds {

--- a/Acornfile
+++ b/Acornfile
@@ -71,7 +71,7 @@ jobs: "delete-cluster": {
 		MONGODB_ATLAS_PUBLIC_API_KEY:  "secret://atlas-creds/public_key"
 		MONGODB_ATLAS_PRIVATE_API_KEY: "secret://atlas-creds/private_key"
 		MONGODB_ATLAS_PROJECT_ID:      "secret://atlas-creds/project_id"
-		CLUSTER_NAME:                  args.clusterName
+		CREATED_CLUSTER:               "secret://state/created_cluster"
 		CREATED_DB_ROOT_USER:          "secret://state/created_db_root_user"
 		CREATED_DB_USER:               "secret://state/created_db_user"
 	}

--- a/Acornfile
+++ b/Acornfile
@@ -45,6 +45,7 @@ services: atlas: generated: job: "create-cluster"
 jobs: "create-cluster": {
 	build: context: "."
 	env: {
+		ACORN_EXTERNAL_ID:             "@{acorn.externalID}"
 		MONGODB_ATLAS_PUBLIC_API_KEY:  "secret://atlas-creds/public_key"
 		MONGODB_ATLAS_PRIVATE_API_KEY: "secret://atlas-creds/private_key"
 		MONGODB_ATLAS_PROJECT_ID:      "secret://atlas-creds/project_id"
@@ -68,6 +69,7 @@ jobs: "delete-cluster": {
 		}
 	}
 	env: {
+		ACORN_EXTERNAL_ID:             "@{acorn.externalID}"
 		MONGODB_ATLAS_PUBLIC_API_KEY:  "secret://atlas-creds/public_key"
 		MONGODB_ATLAS_PRIVATE_API_KEY: "secret://atlas-creds/private_key"
 		MONGODB_ATLAS_PROJECT_ID:      "secret://atlas-creds/project_id"

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -3,7 +3,7 @@
 
 echo "[create.sh]"
 
-# Make sure this script only repply on an Acorn creation event
+# Make sure this script only replies to an Acorn creation event
 if [ "${ACORN_EVENT}" != "create" ]; then
    echo "ACORN_EVENT must be [create], currently is [${ACORN_EVENT}]"
    exit 0
@@ -54,9 +54,16 @@ fi
 
 # Create db user
 echo "creating a database user"
+CREATED_DB_USER=""
 res=$(atlas dbusers create --username ${DB_USER} --password ${DB_PASS} --role readWrite@${DB_NAME})
 if [ $? -ne 0 ]; then
   echo $res
+  echo "database user not created"
+else
+  # Keep track of created user
+  # Used in the deletion step to prevent deletion of a pre-existing user
+  echo "database user created"
+  CREATED_DB_USER=${DB_USER}
 fi
 
 # Extract proto and host from address returned
@@ -72,6 +79,11 @@ services: atlas: {
   data: {
     proto: "${DB_PROTO}"
     dbName: "${DB_NAME}"
+  }
+}
+secrets: state: {
+  data: {
+    created_user: "${CREATED_DB_USER}"
   }
 }
 EOF

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # set -eo pipefail
 
-echo "-> [create.sh]"
+echo "[create.sh]"
 
 # Make sure this script only repply on an Acorn creation event
 if [ "${ACORN_EVENT}" != "create" ]; then
@@ -9,44 +9,32 @@ if [ "${ACORN_EVENT}" != "create" ]; then
    exit 0
 fi
 
-# Check if cluster with that name already exit
-atlas cluster get ${CLUSTER_NAME} 2>/dev/null
-if [ $? -eq 0 ]; then
-  echo "-> cluster ${CLUSTER_NAME} already exists"
-
-  DB_ADDRESS=$(atlas cluster describe ${CLUSTER_NAME} -o json | jq -r .connectionStrings.standardSrv)
-  DB_PROTO=$(echo $DB_ADDRESS | cut -d':' -f1)
-  DB_HOST=$(echo $DB_ADDRESS | cut -d'/' -f3)
-  echo "DB_ADDRESS: [${DB_ADDRESS}] / DB_PROTO:[${DB_PROTO}] / DB_HOST:[${DB_HOST}]"
-
-  cat > /run/secrets/output<<EOF
-  services: atlas: {
-    address: "${DB_HOST}"
-    secrets: ["user"]
-    ports: "27017"
-    data: {
-      proto: "${DB_PROTO}"
-      dbName: "${DB_NAME}"
-    }
-  }
-EOF
-  exit 0
-else
-  echo "-> cluster ${CLUSTER_NAME} does not exist"
-fi
+# Check if cluster with that name already exits
+res=$(atlas cluster list -o json | jq -r --arg cluster_name "$CLUSTER_NAME" '
+  if .results then
+    .results[] | select(.name == $cluster_name)
+  else
+    empty
+  end
+')
+if [ "$res" != "" ]; then
+  echo "cluster ${CLUSTER_NAME} already exists" | tee /dev/termination-log
+  exit 1
+fi 
+echo "cluster ${CLUSTER_NAME} does not exist"
 
 # Create a cluster in the current project
-echo "-> about to create cluster ${CLUSTER_NAME} of type ${TIER} in ${PROVIDER} / ${REGION}"
-result=$(atlas cluster create ${CLUSTER_NAME} --region $REGION --provider $PROVIDER --tier $TIER --tag creator=acorn_service --mdbVersion $DB_VERSION)
+echo "about to create cluster ${CLUSTER_NAME} of type ${TIER} in ${PROVIDER} / ${REGION}"
+res=$(atlas cluster create ${CLUSTER_NAME} --region $REGION --provider $PROVIDER --tier $TIER --tag acornid=${ACORN_EXTERNAL_ID} --mdbVersion $DB_VERSION 2>&1)
 
 # Make sure the cluster was created correctly
 if [ $? -ne 0 ]; then
-  echo $result
+  echo $res | tee /dev/termination-log
   exit 1
 fi
 
 # Wait for Atlas to provide cluster's connection string
-echo "-> waiting for database address"
+echo "waiting for database address"
 while true; do
   DB_ADDRESS=$(atlas cluster describe ${CLUSTER_NAME} -o json | jq -r .connectionStrings.standardSrv)
   if [ "${DB_ADDRESS}" = "null" ]; then
@@ -58,14 +46,14 @@ while true; do
 done
 
 # Allow database network access from current IP
-echo "-> allowing connection from current IP address"
+echo "allowing connection from current IP address"
 res=$(atlas accessList create --currentIp)
 if [ $? -ne 0 ]; then
   echo $res
 fi
 
 # Create db user
-echo "-> creating a database user"
+echo "creating a database user"
 res=$(atlas dbusers create --username ${DB_USER} --password ${DB_PASS} --role readWrite@${DB_NAME})
 if [ $? -ne 0 ]; then
   echo $res
@@ -74,7 +62,7 @@ fi
 # Extract proto and host from address returned
 DB_PROTO=$(echo $DB_ADDRESS | cut -d':' -f1)
 DB_HOST=$(echo $DB_ADDRESS | cut -d'/' -f3)
-echo "-> connection string: [${DB_PROTO}://${DB_USER}:${DB_PASS}@${DB_HOST}]"
+echo "connection string: [${DB_PROTO}://${DB_USER}:${DB_PASS}@${DB_HOST}]"
 
 cat > /run/secrets/output<<EOF
 services: atlas: {

--- a/scripts/delete.sh
+++ b/scripts/delete.sh
@@ -40,11 +40,15 @@ else
   echo "cluster deleted" 
 fi
 
-# Delete user
-echo "-> deleting associated user ${DB_USER}"
-res=$(atlas dbusers delete --force ${DB_USER})
-if [ $? -ne 0 ]; then
-  echo "error deleting dbuser: $res"
+# Delete user (only if created by this service)
+if [ "${CREATED_USER}" != "" ]; then
+  echo "deleting db user ${CREATED_USER}"
+  res=$(atlas dbusers delete --force ${CREATED_USER})
+  if [ $? -ne 0 ]; then
+    echo "error deleting dbuser: $res"
+  else
+    echo "dbuser deleted"
+  fi
 else
-  echo "dbuser deleted"
-fi
+  echo "no user to delete as none was created by this service"
+fi 

--- a/scripts/delete.sh
+++ b/scripts/delete.sh
@@ -1,31 +1,50 @@
 #!/bin/sh
 # set -eo pipefail
 
-echo "-> [delete.sh]"
+echo "[delete.sh]"
 
-# Make sure this script only repply on an Acorn deletion event
+# Make sure this script only replies to an Acorn deletion event
 if [ "${ACORN_EVENT}" != "delete" ]; then
    echo "ACORN_EVENT must be [delete], currently is [${ACORN_EVENT}]"
    exit 0
 fi
 
-# Make sure the cluster exists
-atlas cluster get ${CLUSTER_NAME} 2>/dev/null
-if [ $? -ne 0 ]; then
-  echo "cluster ${CLUSTER_NAME} does not exist"
+# Make sure a cluster with the name provided exists
+cluster=$(atlas cluster list -o json | jq -r --arg cluster_name "$CLUSTER_NAME" '
+  if .results then
+    .results[] | select(.name == $cluster_name)
+  else
+    empty
+  end
+')
+if [ "$cluster" = "" ]; then
+  echo "cluster ${CLUSTER_NAME} does not exists" | tee /dev/termination-log
+  exit 1
+fi 
+echo "cluster ${CLUSTER_NAME} found"
+
+# Make sure the cluster retrieved has the correct acornid tag
+cluster_acorn_id=$(echo $cluster | jq -r '.tags[] | select(.key == "acornid") | .value')
+if [ "$cluster_acorn_id" != "$ACORN_EXTERNAL_ID" ]; then
+  echo "cluster ${CLUSTER_NAME} does not have the correct Acorn ID ($ACORN_EXTERNAL_ID) => atlas cluster will not be deleted"
   exit 0
 fi
+echo "cluster ${CLUSTER_NAME} has the correct Acorn ID ($ACORN_EXTERNAL_ID)"
 
 # Delete the cluster
-echo "-> deleting cluster ${CLUSTER_NAME}"
+echo "deleting cluster ${CLUSTER_NAME}"
 res=$(atlas cluster delete --force ${CLUSTER_NAME})
 if [ $? -ne 0 ]; then
-  echo $res
+  echo "error deleting cluster: $res"
+else
+  echo "cluster deleted" 
 fi
 
 # Delete user
 echo "-> deleting associated user ${DB_USER}"
 res=$(atlas dbusers delete --force ${DB_USER})
 if [ $? -ne 0 ]; then
-  echo $res
+  echo "error deleting dbuser: $res"
+else
+  echo "dbuser deleted"
 fi


### PR DESCRIPTION
Acorn External ID is used to tag the atlas cluster created, and verified in the deletion step.

Currently, if a user exists before the acorn creates the cluster, no new user will be created. But... in the deletion step the original user will be deleted. This is a corner case which still need to be fixed.